### PR TITLE
Update woocommerce-jadlog.php

### DIFF
--- a/woocommerce-jadlog/woocommerce-jadlog.php
+++ b/woocommerce-jadlog/woocommerce-jadlog.php
@@ -15,8 +15,6 @@
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
-session_start();
-
 /* Exit if accessed directly */
 if (!defined('ABSPATH'))
     exit;


### PR DESCRIPTION
session_start() removido por causar erro crítico no wordpress, pull request criado com a correção no jadlogShippmentInit